### PR TITLE
Add streams

### DIFF
--- a/configure.bat
+++ b/configure.bat
@@ -1,6 +1,6 @@
 rd /s /q cmake-build-debug
 ::cmake -H. -Bcmake-build-debug -G"Visual Studio 15 2017 Win64" -DOCTORAD_DUMP_DIR=C:/Users/Parsa/Desktop/arg-dumps -DOCTORAD_WITH_VC=ON -DVc_DIR="C:/Repos/Vc/cmake-install-debug/lib/cmake/Vc" -DOCTORAD_WITH_SCRATCHPAD=ON
-cmake -H. -Bcmake-build-debug -G"Visual Studio 15 2017 Win64" -DOCTORAD_DUMP_DIR=C:/Users/Parsa/Desktop/arg-dumps -DOCTORAD_WITH_SCRATCHPAD=ON -DOCTORAD_DUMP_COUNT=13140
+cmake -H. -Bcmake-build-debug -G"Visual Studio 15 2017 Win64" -DOCTORAD_DUMP_DIR=C:/Users/Parsa/Desktop/arg-dumps -DOCTORAD_DUMP_COUNT=13140 -DOCTORAD_WITH_SCRATCHPAD=ON -DOCTORAD_WITH_PLAYGROUND=ON
 cmake --build cmake-build-debug --target fidelity_test
 pause
 cmake --open cmake-build-debug

--- a/radiation/kernels/helpers.hpp
+++ b/radiation/kernels/helpers.hpp
@@ -28,6 +28,15 @@ T* device_alloc(std::size_t const size)
 }
 
 template <typename T>
+T* device_copy_from_host_async(T* const device_ptr, T* const payload,
+    std::size_t const payload_size, cudaStream_t stream)
+{
+    throw_if_cuda_error(cudaMemcpyAsync(device_ptr, payload,
+        payload_size * sizeof(T), cudaMemcpyHostToDevice, stream));
+    return device_ptr;
+}
+
+template <typename T>
 T* device_copy_from_host(
     T* const device_ptr, T* const payload, std::size_t const payload_size)
 {
@@ -37,7 +46,8 @@ T* device_copy_from_host(
 }
 
 template <typename T, typename Allocator>
-T* device_copy_from_host(T* const device_ptr, std::vector<T, Allocator> const& v)
+T* device_copy_from_host(
+    T* const device_ptr, std::vector<T, Allocator> const& v)
 {
     throw_if_cuda_error(cudaMemcpy(
         device_ptr, &v[0], v.size() * sizeof(T), cudaMemcpyHostToDevice));
@@ -65,11 +75,20 @@ T* device_alloc_copy_from_host(std::vector<T, Allocator> const& v)
 }
 
 template <typename T, typename Allocator, std::size_t N>
-T* device_alloc_copy_from_host(std::array<std::vector<T, Allocator>, N> const& a)
+T* device_alloc_copy_from_host(
+    std::array<std::vector<T, Allocator>, N> const& a)
 {
     T* const device_ptr = device_alloc<T>(N * a[0].size());
     device_copy_from_host<T, N>(device_ptr, a);
     return device_ptr;
+}
+
+template <typename T>
+void device_copy_to_host_async(T const* const device_ptr, T* const payload,
+    std::size_t const payload_size, cudaStream_t stream)
+{
+    throw_if_cuda_error(cudaMemcpyAsync(payload, device_ptr,
+        payload_size * sizeof(T), cudaMemcpyDeviceToHost, stream));
 }
 
 template <typename T>
@@ -81,7 +100,8 @@ void device_copy_to_host(
 }
 
 template <typename T, typename Allocator>
-void device_copy_to_host(T const* const device_ptr, std::vector<T, Allocator>& v)
+void device_copy_to_host(
+    T const* const device_ptr, std::vector<T, Allocator>& v)
 {
     throw_if_cuda_error(cudaMemcpy(
         &v[0], device_ptr, v.size() * sizeof(T), cudaMemcpyDeviceToHost));

--- a/radiation/kernels/helpers.hpp
+++ b/radiation/kernels/helpers.hpp
@@ -165,7 +165,7 @@ public:
     using value_type = T;
     using pointer = T*;
     using reference = T&;
-    using const_reference = const T&;
+    using const_reference = T const&;
 
     cuda_host_allocator() {}
 

--- a/radiation/kernels/kernel_gpu.cu
+++ b/radiation/kernels/kernel_gpu.cu
@@ -3,6 +3,7 @@
 #include "kernels/kernel_gpu.hpp"
 
 #include <array>
+#include <atomic>
 #include <cassert>
 #include <cmath>
 #include <cstddef>
@@ -28,19 +29,8 @@ constexpr std::size_t PAYLOAD_I_SIZE = 4 * GRID_ARRAY_SIZE;
 constexpr std::size_t PAYLOAD_O_SIZE = (5 + NRF) * GRID_ARRAY_SIZE;
 constexpr std::size_t PAYLOAD_SIZE = PAYLOAD_O_SIZE + PAYLOAD_I_SIZE;
 
-struct device_stream
-{
-    device_stream()
-    {
-        cudaStreamCreate(&stream);
-    }
-    ~device_stream()
-    {
-        cudaStreamDestroy(stream);
-    }
-
-    cudaStream_t stream;
-};
+std::atomic_size_t stream_top{};
+std::vector<cudaStream_t> streams;
 
 struct payload_t
 {
@@ -492,23 +482,33 @@ namespace octotiger {
         cudaFree(0);
     }
 
-    radiation_gpu_kernel::radiation_gpu_kernel(std::size_t strm_idx)
+    radiation_gpu_kernel::radiation_gpu_kernel()
       : d_payload(device_alloc<double>(PAYLOAD_SIZE))
       // batch small transfers into a single transfer to reduce memcpy overhead
       , h_payload_ptr(host_pinned_alloc<double>(PAYLOAD_SIZE))
     {
+        stream_index = stream_top++;
+        streams.emplace_back(cudaStream_t{});
+        assert(stream_top == streams.size());
+        cudaStreamCreate(&streams[stream_index]);
     }
 
     radiation_gpu_kernel::radiation_gpu_kernel(radiation_gpu_kernel&& other)
     {
         std::swap(d_payload, other.d_payload);
         std::swap(h_payload_ptr, other.h_payload_ptr);
+        std::swap(stream_index, other.stream_index);
+        other.moved = true;
     }
 
     radiation_gpu_kernel::~radiation_gpu_kernel()
     {
-        device_free(d_payload);
-        host_pinned_free(h_payload_ptr);
+        if (!moved)
+        {
+            device_free(d_payload);
+            host_pinned_free(h_payload_ptr);
+            cudaStreamDestroy(streams[stream_index]);
+        }
     }
 
     void radiation_gpu_kernel::operator()(std::int64_t const opts_eos,
@@ -571,13 +571,13 @@ namespace octotiger {
         }
 
         device_copy_from_host_async(
-            d_payload, h_payload_ptr, PAYLOAD_SIZE, stream.stream);
+            d_payload, h_payload_ptr, PAYLOAD_SIZE, streams[stream_index]);
 
         // launch the kernel
         launch_kernel(radiation_impl,                    // kernel
             dim3(1),                                     // grid dims
             dim3(RAD_GRID_I, RAD_GRID_I, RAD_GRID_I),    // block dims
-            stream.stream,                               // stream
+            streams[stream_index],                       // stream
             opts_eos,                                    //
             opts_problem,                                //
             opts_dual_energy_sw1,                        //
@@ -599,8 +599,8 @@ namespace octotiger {
         );
 
         device_copy_to_host_async(
-            d_payload, h_payload_ptr, PAYLOAD_O_SIZE, stream.stream);
-        cudaStreamSynchronize(stream.stream);
+            d_payload, h_payload_ptr, PAYLOAD_O_SIZE, streams[stream_index]);
+        cudaStreamSynchronize(streams[stream_index]);
 
         {
             std::size_t index_counter{};

--- a/radiation/kernels/kernel_gpu.cu
+++ b/radiation/kernels/kernel_gpu.cu
@@ -482,6 +482,11 @@ namespace octotiger {
         cudaFree(0);
     }
 
+    void device_reset()
+    {
+        cudaDeviceReset();
+    }
+
     radiation_gpu_kernel::radiation_gpu_kernel()
       : d_payload(device_alloc<double>(PAYLOAD_SIZE))
       // batch small transfers into a single transfer to reduce memcpy overhead

--- a/radiation/kernels/kernel_gpu.hpp
+++ b/radiation/kernels/kernel_gpu.hpp
@@ -10,11 +10,9 @@
 namespace octotiger {
     void device_init();
 
-    struct device_stream;
-
     struct radiation_gpu_kernel
     {
-        radiation_gpu_kernel(std::size_t strm_idx = 0);
+        radiation_gpu_kernel();
         radiation_gpu_kernel(radiation_gpu_kernel const&) = delete;
         radiation_gpu_kernel(radiation_gpu_kernel&& other);
         ~radiation_gpu_kernel();
@@ -34,8 +32,9 @@ namespace octotiger {
             double const clightinv);
 
     private:
-        double* d_payload;
-        double* h_payload_ptr;
-        device_stream stream;
+        bool moved = false;
+        double* d_payload = nullptr;
+        double* h_payload_ptr = nullptr;
+        std::size_t stream_index;
     };
 }

--- a/radiation/kernels/kernel_gpu.hpp
+++ b/radiation/kernels/kernel_gpu.hpp
@@ -10,9 +10,11 @@
 namespace octotiger {
     void device_init();
 
+    struct device_stream;
+
     struct radiation_gpu_kernel
     {
-        radiation_gpu_kernel();
+        radiation_gpu_kernel(std::size_t strm_idx = 0);
         radiation_gpu_kernel(radiation_gpu_kernel const&) = delete;
         radiation_gpu_kernel(radiation_gpu_kernel&& other);
         ~radiation_gpu_kernel();
@@ -34,5 +36,6 @@ namespace octotiger {
     private:
         double* d_payload;
         double* h_payload_ptr;
+        device_stream stream;
     };
 }

--- a/radiation/kernels/kernel_gpu.hpp
+++ b/radiation/kernels/kernel_gpu.hpp
@@ -9,6 +9,7 @@
 
 namespace octotiger {
     void device_init();
+    void device_reset();
 
     struct radiation_gpu_kernel
     {

--- a/radiation/tests/profile_83_test.cpp
+++ b/radiation/tests/profile_83_test.cpp
@@ -16,8 +16,8 @@
 #include <utility>
 #include <vector>
 
-constexpr std::size_t ITERATIONS = 100000;
-constexpr std::size_t MAX_STREAMS = 3;
+constexpr std::size_t ITERATIONS = 20000;
+constexpr std::size_t MAX_STREAMS = 4;
 
 using run_ret_t = std::pair<double, std::size_t>;
 
@@ -119,6 +119,8 @@ int main()
         octotiger::fx_case test_case = octotiger::import_case(83);
 
         profile_kernel<octotiger::radiation_gpu_kernel>(test_case);
+
+        octotiger::device_reset();
     }
     catch (std::exception const& e)
     {

--- a/radiation/tests/profile_83_test.cpp
+++ b/radiation/tests/profile_83_test.cpp
@@ -16,7 +16,8 @@
 #include <utility>
 #include <vector>
 
-constexpr std::size_t ITERATIONS = 10000;
+constexpr std::size_t ITERATIONS = 100000;
+constexpr std::size_t MAX_STREAMS = 3;
 
 using run_ret_t = std::pair<double, std::size_t>;
 
@@ -55,8 +56,6 @@ void profile_kernel(octotiger::fx_case& test_case)
     double pure_et{};
     {
         scoped_timer<double> timer(overall_et);
-
-        constexpr std::size_t MAX_STREAMS = 4;
 
         // MAX_STREAMS kernels, each with a different stream
         std::vector<case_runner<K>> workers;

--- a/radiation/tests/profile_83_test.cpp
+++ b/radiation/tests/profile_83_test.cpp
@@ -10,16 +10,24 @@
 
 #include <chrono>
 #include <cstdio>
+#include <future>
 #include <random>
 #include <ratio>
+#include <utility>
 #include <vector>
 
 constexpr std::size_t ITERATIONS = 10000;
 
+using run_ret_t = std::pair<double, std::size_t>;
+
 template <typename K>
 struct case_runner
 {
-    double operator()(octotiger::fx_case test_case)
+    case_runner(std::size_t idx = 0)
+    {
+        index = idx;
+    }
+    run_ret_t operator()(octotiger::fx_case test_case)
     {
         duration = 0.0;
         {
@@ -31,12 +39,13 @@ struct case_runner
                 a.egas, a.tau, a.fgamma, a.U, a.mmw, a.X_spc, a.Z_spc, a.dt,
                 a.clightinv);
         }
-        return duration;
+        return std::make_pair(duration, index);
     }
 
 private:
     K kernel;
     double duration{};
+    std::size_t index;
 };
 
 template <typename K>
@@ -46,11 +55,43 @@ void profile_kernel(octotiger::fx_case& test_case)
     double pure_et{};
     {
         scoped_timer<double> timer(overall_et);
-        case_runner<K> run_cpu_case;
-        for (std::size_t i = 0; i < ITERATIONS; ++i)
+        case_runner<K> run_kernel_case;
+
+        std::vector<std::future<run_ret_t>> case_queue;
+        std::vector<case_runner<K>> workers;
+        for (std::size_t wi = 0; wi < 3; wi++)
         {
-            pure_et += run_cpu_case(test_case);
+            workers.emplace_back(case_runner<K>{wi});
         }
+
+        std::size_t i = 0;
+        for (std::size_t wi = 0; wi < 3; wi++)
+        {
+            case_queue.emplace_back(std::async(std::launch::async,
+                [&]() { return run_kernel_case(test_case); }));
+            ++i;
+        }
+        while (i < ITERATIONS)
+        {
+            for (auto& t : case_queue)
+            {
+                if (std::future_status::ready ==
+                    t.wait_for(std::chrono::seconds::zero()))
+                {
+                    auto r = t.get();
+                    pure_et += r.first;
+                    t = std::async(std::launch::async, [&, i = r.second]() {
+                        return run_kernel_case(test_case);
+                    });
+                    ++i;
+                }
+            }
+        }
+
+        //for (std::size_t i = 0; i < ITERATIONS; ++i)
+        //{
+        //    pure_et += run_kernel_case(test_case);
+        //}
     }
     std::printf("total kernel execution time: %gus\n", pure_et);
     std::printf("overall execution time: %gs\n", overall_et);


### PR DESCRIPTION
Add streams to the code.

Needs serious cleanup
* If it is possible to not have the globals `std::atomic_size_t stream_top` and `std::vector<cudaStream_t> streams` and somehow not expose streams to the calling code, they should be removed
* Stream scheduling test code must be improved.
* Raw pointers in the kernel code must be replaced by something more reasonable.